### PR TITLE
fix: resolve YAML parsing error by using proper stringify function

### DIFF
--- a/.cursor/rules/new-feature.mdc
+++ b/.cursor/rules/new-feature.mdc
@@ -1,14 +1,5 @@
 ---
-title: New Feature
-description: A new feature has been added to the project
-files: mdc:src/feature.ts
-  - mdc:test/feature.test.ts
-globs: "src/**/*.ts"
-  - "test/**/*.ts"
+description:
+globs:
+alwaysApply: false
 ---
-
-A new feature has been added to the project
-
-## Files
-- [src/feature.ts](mdc:src/feature.ts)
-- [test/feature.test.ts](mdc:test/feature.test.ts)

--- a/src/generate-cursor-rule.ts
+++ b/src/generate-cursor-rule.ts
@@ -3,7 +3,7 @@ import OpenAI from 'openai';
 import { config } from 'dotenv';
 import { mkdir, writeFile } from 'fs/promises';
 import { join } from 'path';
-import { parse } from 'yaml';
+import { parse, stringify } from 'yaml';
 
 config();
 
@@ -97,12 +97,14 @@ globs: string[]`;
     const ruleName = ruleContent.title.toLowerCase().replace(/\s+/g, '-');
     const rulePath = join('.cursor', 'rules', `${ruleName}.mdc`);
     
-    const ruleContentString = `---
-title: ${ruleContent.title}
-description: ${ruleContent.description}
-files: ${ruleContent.files.map(f => `mdc:${f}`).join('\n  - ')}
-globs: ${ruleContent.globs.map(g => `"${g}"`).join('\n  - ')}
----
+    const frontMatter = {
+      title: ruleContent.title,
+      description: ruleContent.description,
+      files: ruleContent.files.map(f => `mdc:${f}`),
+      globs: ruleContent.globs
+    };
+    
+    const ruleContentString = `---\n${stringify(frontMatter)}---
 
 ${ruleContent.description}
 


### PR DESCRIPTION
## Changes
- Fixed YAML parsing error by using proper `stringify` function from the `yaml` package
- Improved YAML front matter formatting in generated rule files
- Ensured proper indentation and structure of YAML content

## Testing
The changes have been tested to ensure that:
- YAML parsing no longer throws "MULTILINE_IMPLICIT_KEY" errors
- Generated rule files maintain proper YAML formatting
- The functionality of the rule generation remains intact